### PR TITLE
Introduct GitHub Action for deliverying GitHub Package.

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,39 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version in semantic versioning format (i.e. 1.0.2)'
+        required: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@salemove'
+
+      - name: Authenticate to GitHub Packages
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.PAT_TOKEN }}" > ~/.npmrc
+
+      - name: Install dependencies
+        run: npm install
+
+      - run: npm ci
+
+      # Publishing packages
+      - run: npm pkg set version='${{ github.event.inputs.version }}'
+      - run: npm publish --tag stable


### PR DESCRIPTION
This Action requires adding to repo secrets `PAT_TOKEN`.

# Create PAT
> Create a Personal Access Token (PAT) on GitHub with the **write:packages** and **read:packages** permissions:
> Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic).
> Generate a token and copy it.

# Add to Secrets (optional, perhaps you already have it)
> Go to the organization's Settings.
> Navigate to Secrets and variables → Actions.
> Add a new secret there.
> Configure which repositories can access the secret.