### PR TITLE
Fix "npm show" execution

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,22 +10,16 @@ jobs:
   package_publishing:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
-      id-token: write
     env:
       ACTIONS_STEP_DEBUG: true
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@salemove'
 
       - name: Authenticate to GitHub Packages
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
@@ -35,6 +29,13 @@ jobs:
 
       - run: npm ci
 
-      # Publishing packages
-      - run: npm pkg set version='${{ github.event.inputs.version }}'
-      - run: npm publish --tag stable
+      - name: Create dist folder
+        run: npm run build
+
+      - name: Set package version
+        run: npm pkg set version='${{ github.event.inputs.version }}'
+
+      - name: Publishing packages
+        run: npm publish --@salemove:registry=https://npm.pkg.github.com/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@salemove:registry=https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
     "url": "git+https://github.com/salemove/widgets_sdk_ionic"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   },
   "bugs": {
     "url": "https://github.com/salemove/ios-sdk-widgets/issues"
   },
   "keywords": [
-    "capacitor",
-    "plugin",
-    "native"
+    "Glia",
+    "GliaWidgets",
+    "GliaWidgetsSDK"
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",


### PR DESCRIPTION
`npm show` and `npm view` didn't work because of mixed registry setting on CI side and in .npmrc file. Additionally this fix, I also added some minor clean up.

Feel free to check how this fix works using this
```sh
npm view @dukhovnyi/widgets_sdk_ionic --registry=https://npm.pkg.github.com
```