### PR TITLE
Fix "npm show" execution

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,22 +10,16 @@ jobs:
   package_publishing:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
-      id-token: write
     env:
       ACTIONS_STEP_DEBUG: true
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@salemove'
 
       - name: Authenticate to GitHub Packages
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
@@ -35,6 +29,13 @@ jobs:
 
       - run: npm ci
 
-      # Publishing packages
-      - run: npm pkg set version='${{ github.event.inputs.version }}'
-      - run: npm publish --tag stable
+      - name: Create dist folder
+        run: npm run build
+
+      - name: Set package version
+        run: npm pkg set version='${{ github.event.inputs.version }}'
+
+      - name: Publishing packages
+        run: npm publish --@salemove:registry=https://npm.pkg.github.com/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@salemove:registry=https://npm.pkg.github.com/

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ GliaWidgets SDK is a simple and customisable framework built on top of GliaSDK. 
 
 ## Installation
 
-To install version 3.0.0 of this package use:
+To install the @salemove/widgets_sdk_ionic package use:
 
 ```text
-npm install github:salemove/widgets_sdk_ionic
+npm install @salemove/widgets_sdk_ionic
 ```
 
 # How to use GliaSDK in Ionic environment

--- a/SalemoveWidgetsSdkIonic.podspec
+++ b/SalemoveWidgetsSdkIonic.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'GliaWidgetsIonic'
+  s.name = 'SalemoveWidgetsSdkIonic'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/example-app/ios/App/Podfile
+++ b/example-app/ios/App/Podfile
@@ -13,7 +13,7 @@ def capacitor_pods
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCamera', :path => '../../node_modules/@capacitor/camera'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
-  pod 'GliaWidgetsIonic', :path => '../../..'
+  pod 'SalemoveWidgetsSdkIonic', :path => '../../..'
 end
 
 target 'App' do

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
     "url": "git+https://github.com/salemove/widgets_sdk_ionic"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   },
   "bugs": {
     "url": "https://github.com/salemove/ios-sdk-widgets/issues"
   },
   "keywords": [
-    "capacitor",
-    "plugin",
-    "native"
+    "Glia",
+    "GliaWidgets",
+    "GliaWidgetsSDK"
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "GliaWidgetsIonic.podspec"
+    "SalemoveWidgetsSdkIonic.podspec"
   ],
   "author": "Glia",
   "license": "MIT",


### PR DESCRIPTION
These changes have been made togethere with Yurii. Here is an overview:
1. `npm show` and `npm view` didn't work because of mixed registry setting on CI side and in .npmrc file. In addition to this, I also added some minor clean up.
 
These changes allow the following command to work :
```sh
npm view @salemove/widgets_sdk_ionic --registry=https://npm.pkg.github.com
```

2. Rename podspec to follow GitHub organization scope name