### PR TITLE
fix: break after the invalid Assed ID reject

### DIFF
--- a/ios/Sources/GliaSdkPlugin/GliaSdk.swift
+++ b/ios/Sources/GliaSdkPlugin/GliaSdk.swift
@@ -58,6 +58,7 @@ import GliaWidgets
                 visitorContext = .init(assetId: assetId)
             } else {
                 call.reject("'visitorContextAssetId' is invalid.")
+                return
             }
         }
 


### PR DESCRIPTION
Stop configuring the SDK if it is an invalid Visitor Context Asset ID

MOB-4535