### PR TITLE
Ignore Snyk Dual license issue for the 'javax.annotation:javax.annotation-api' library

### DIFF
--- a/android/.snyk
+++ b/android/.snyk
@@ -1,0 +1,12 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+
+version: v1.25.1
+
+ignore:
+ 'snyk:lic:maven:javax.annotation:javax.annotation-api:(CDDL-1.1_OR_GPL-2.0-with-classpath-exception)':
+  - '*':
+    reason: https://glia.atlassian.net/browse/MOB-4515
+    expires: 2028-01-10T00:00:00.000Z
+    created: 2025-07-30T04:35:33.179Z
+
+patch: {}

--- a/example-app/android/.snyk
+++ b/example-app/android/.snyk
@@ -1,0 +1,12 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+
+version: v1.25.1
+
+ignore:
+ 'snyk:lic:maven:javax.annotation:javax.annotation-api:(CDDL-1.1_OR_GPL-2.0-with-classpath-exception)':
+  - '*':
+    reason: https://glia.atlassian.net/browse/MOB-4515
+    expires: 2028-01-10T00:00:00.000Z
+    created: 2025-07-30T04:35:33.179Z
+
+patch: {}


### PR DESCRIPTION
It was agreed with Security Team to ignore the  Dual license issue for the `javax.annotation:javax.annotation-api` library.
See  [MOB-4515](https://glia.atlassian.net/browse/MOB-4515).

The reason why ignore rule was not working was: for sub projects, `.snyk` should be in project directory, rather than in repo root.

[MOB-4515]: https://glia.atlassian.net/browse/MOB-4515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ