### PR TITLE
fix: automate iOS project build

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -115,4 +115,4 @@ jobs:
       - name: Run iOS Build
         run: |
           cd example-app/ios/App
-          xcodebuild -workspace App.xcworkspace -scheme App -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' -showBuildTimingSummary build
+          xcodebuild -workspace App.xcworkspace -scheme App -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -showBuildTimingSummary build


### PR DESCRIPTION
Update the destination for the build command.
Since GitHub is constantly releasing new versions of the macOS images, which disables the support of some installed simulators, it makes sense to set the latest one as a destination for the long-term support.