### PR TITLE
Fix vulnarability detected in netty dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,7 @@ allprojects {
         resolutionStrategy {
             force 'com.google.protobuf:protobuf-java:3.25.5'
             force 'com.google.protobuf:protobuf-java-util:3.25.5'
-            force 'io.netty:netty-codec-http2:4.1.118.Final'
+            force 'io.netty:netty-codec-http2:4.1.125.Final'
         }
     }
 }

--- a/example-app/android/build.gradle
+++ b/example-app/android/build.gradle
@@ -28,7 +28,7 @@ allprojects {
         resolutionStrategy {
             force 'com.google.protobuf:protobuf-java:3.25.5'
             force 'com.google.protobuf:protobuf-java-util:3.25.5'
-            force 'io.netty:netty-codec-http2:4.1.118.Final'
+            force 'io.netty:netty-codec-http2:4.1.125.Final'
         }
     }
 }


### PR DESCRIPTION
The issue was detected by Snyk. Related link https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-12485149.

The issue was fixed in the newer Netty dependency, so just upgrading its version.